### PR TITLE
Configuration doesnt explode if it doesnt exist

### DIFF
--- a/docs/src/config.html
+++ b/docs/src/config.html
@@ -85,6 +85,9 @@
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">fromFile</span><span class="hljs-params">(configFilePath)</span> </span>{
+  <span class="hljs-keyword">if</span> (!fs.existsSync(configFilePath)) {
+    <span class="hljs-keyword">return</span> {};
+  }
   <span class="hljs-keyword">var</span> contents = fs.readFileSync(configFilePath);
   <span class="hljs-keyword">return</span> <span class="hljs-built_in">JSON</span>.parse(contents);
 }</pre></div></div>

--- a/docs/src/config.html
+++ b/docs/src/config.html
@@ -66,7 +66,8 @@
             </div>
             
             <div class="content"><div class='highlight'><pre>
-<span class="hljs-keyword">var</span> fs = <span class="hljs-built_in">require</span>(<span class="hljs-string">'fs'</span>)
+<span class="hljs-keyword">var</span> fs            = <span class="hljs-built_in">require</span>(<span class="hljs-string">'fs'</span>)
+,   path          = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>)
 ,   expandHomeDir = <span class="hljs-built_in">require</span>(<span class="hljs-string">'expand-home-dir'</span>);
 
 <span class="hljs-keyword">var</span> DEFAULT_CONFIG_FILE = expandHomeDir(<span class="hljs-string">'~/.hop/config'</span>);</pre></div></div>
@@ -106,6 +107,9 @@
             </div>
             
             <div class="content"><div class='highlight'><pre><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">toFile</span><span class="hljs-params">(configFilePath, config)</span> </span>{
+  <span class="hljs-keyword">if</span> (!fs.existsSync(configFilePath)) {
+    fs.mkdirSync(path.dirname(configFilePath));
+  }
   fs.writeFileSync(configFilePath, <span class="hljs-built_in">JSON</span>.stringify(config));
 }</pre></div></div>
             

--- a/src/config.js
+++ b/src/config.js
@@ -9,6 +9,9 @@ var DEFAULT_CONFIG_FILE = expandHomeDir('~/.hop/config');
 
 // Loads configuration from path, parses JSON and returns POJO
 function fromFile(configFilePath) {
+  if (!fs.existsSync(configFilePath)) {
+    return {};
+  }
   var contents = fs.readFileSync(configFilePath);
   return JSON.parse(contents);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,8 @@
 
 // Configuration, by default, is stored in `~/.hop/config`
 
-var fs = require('fs')
+var fs            = require('fs')
+,   path          = require('path')
 ,   expandHomeDir = require('expand-home-dir');
 
 var DEFAULT_CONFIG_FILE = expandHomeDir('~/.hop/config');
@@ -18,6 +19,9 @@ function fromFile(configFilePath) {
 
 // Stringifies POJO to JSON and overwrites the config file
 function toFile(configFilePath, config) {
+  if (!fs.existsSync(configFilePath)) {
+    fs.mkdirSync(path.dirname(configFilePath));
+  }
   fs.writeFileSync(configFilePath, JSON.stringify(config));
 }
 

--- a/test/config_tests.js
+++ b/test/config_tests.js
@@ -1,4 +1,5 @@
 var c      = require('../src/config')
+,   fs     = require('fs')
 ,   path   = require('path')
 ,   assert = require('assert');
 
@@ -20,4 +21,20 @@ var configFilePath = path.resolve('test/fixtures/nonexistant-config');
 var loadedConfig = c.fromFile(configFilePath);
 assert.deepEqual(loadedConfig, {});
 
+
+
+ensureNonexistantConfigDoesntExist();
+var configFilePath = path.resolve('test/fixtures/nonexistant-directory/nonexistant-config');
+c.toFile(configFilePath, {});
+ensureNonexistantConfigDoesntExist();
+
 console.log("OK!");
+
+function ensureNonexistantConfigDoesntExist() {
+  try {
+    fs.unlinkSync('test/fixtures/nonexistant-directory/nonexistant-config');
+    fs.rmdirSync('test/fixtures/nonexistant-directory');
+  } catch(err) {
+    // We expect this not to exist, unless something else failed;
+  }
+}

--- a/test/config_tests.js
+++ b/test/config_tests.js
@@ -13,6 +13,11 @@ config.workspaces[workspaceB] = { depth: 2 };
 var configFilePath = path.resolve('test/fixtures/boring-config');
 
 c.toFile(configFilePath, config);
-
 var loadedConfig = c.fromFile(configFilePath);
 assert.deepEqual(loadedConfig, config);
+
+var configFilePath = path.resolve('test/fixtures/nonexistant-config');
+var loadedConfig = c.fromFile(configFilePath);
+assert.deepEqual(loadedConfig, {});
+
+console.log("OK!");


### PR DESCRIPTION
Installing on a new machine would cause `projects` command to poop out because no config file exists instead of just not finding any workspaces.
